### PR TITLE
Build with fiber support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/README.md
+++ b/README.md
@@ -3,62 +3,6 @@ About tracy-profiler-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/tracy-feedstock/blob/main/LICENSE.txt)
 
-
-About tracy-profiler
---------------------
-
-Home: https://github.com/wolfpld/tracy
-
-Package license: [BSD-3-Clause](https://github.com/wolfpld/tracy/blob/master/LICENSE)
-
-Summary: A real time, nanosecond resolution, remote telemetry, hybrid frame and 
-sampling profiler for games and other applications.
-
-
-Development: https://github.com/wolfpld/tracy
-
-About tracy-profiler-client
----------------------------
-
-Home: https://github.com/wolfpld/tracy
-
-Package license: [BSD-3-Clause](https://github.com/wolfpld/tracy/blob/master/LICENSE)
-
-Summary: A real time, nanosecond resolution, remote telemetry, hybrid frame and
-sampling profiler for games and other applications.
-
-
-Development: https://github.com/wolfpld/tracy
-
-About tracy-profiler-gui
-------------------------
-
-Home: https://github.com/wolfpld/tracy
-
-Package license: [BSD-3-Clause](https://github.com/wolfpld/tracy/blob/master/LICENSE)
-
-Summary: A real time, nanosecond resolution, remote telemetry, hybrid frame and
-sampling profiler for games and other applications.
-
-
-Development: https://github.com/wolfpld/tracy
-
-About tracy-profiler-client-python
-----------------------------------
-
-Home: https://github.com/wolfpld/tracy
-
-Package license: [BSD-3-Clause](https://github.com/wolfpld/tracy/blob/master/LICENSE)
-
-Summary: A real time, nanosecond resolution, remote telemetry, hybrid frame and
-sampling profiler for games and other applications.
-
-
-Development: https://github.com/wolfpld/tracy
-
-About tracy-profiler
---------------------
-
 Home: https://github.com/wolfpld/tracy
 
 Package license: [BSD-3-Clause](https://github.com/wolfpld/tracy/blob/master/LICENSE)

--- a/recipe/build_tracy_client.bat
+++ b/recipe/build_tracy_client.bat
@@ -8,7 +8,8 @@ cmake .. ^
     -DBUILD_SHARED_LIBS=ON ^
     -GNinja ^
     -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
-    -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%"
+    -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+    -DTRACY_FIBERS=ON
 
 :: build
 cmake --build . --parallel %CPU_COUNT%

--- a/recipe/build_tracy_client.sh
+++ b/recipe/build_tracy_client.sh
@@ -7,7 +7,8 @@ mkdir build && cd build
 cmake ${CMAKE_ARGS} .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=ON \
-    -GNinja
+    -GNinja \
+    -DTRACY_FIBERS=ON
 
 # build
 cmake --build . --parallel ${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - patches/0004-Add-install-rule.patch
 
 build:
-  number: 4
+  number: 5
 
 outputs:
   - name: {{ pkg_name }}-client
@@ -110,7 +110,7 @@ outputs:
 about:
   home: https://github.com/wolfpld/tracy
   summary: |
-    A real time, nanosecond resolution, remote telemetry, hybrid frame and 
+    A real time, nanosecond resolution, remote telemetry, hybrid frame and
     sampling profiler for games and other applications.
   license: BSD-3-Clause
   license_family: BSD

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ source:
     - patches/0003-Avoid-linking-issues-when-linking-against-conda-pack.patch
     # Add instal rule
     - patches/0004-Add-install-rule.patch
+    # Add TRACY_FIBERS definition when it's enabled
+    - patches/0005-Add-DTRACY_FIBERS-ON-to-TracyClient-target-when-TRAC.patch
 
 build:
   number: 5

--- a/recipe/patches/0005-Add-DTRACY_FIBERS-ON-to-TracyClient-target-when-TRAC.patch
+++ b/recipe/patches/0005-Add-DTRACY_FIBERS-ON-to-TracyClient-target-when-TRAC.patch
@@ -1,0 +1,27 @@
+From 57503495a4018d8e7bf370cc6320f79ff337f321 Mon Sep 17 00:00:00 2001
+From: Jeongseok Lee <jeongseok@meta.com>
+Date: Tue, 28 Jan 2025 13:09:50 -0800
+Subject: [PATCH] Add -DTRACY_FIBERS=ON to TracyClient target when TRACY_FIBERS
+ is enabled
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 72901a8c..8c99d3a7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -36,6 +36,9 @@ target_link_libraries(
+         Threads::Threads
+         ${CMAKE_DL_LIBS}
+ )
++if(TRACY_FIBERS)
++    target_compile_definitions(TracyClient PUBLIC -DTRACY_FIBERS=ON)
++endif()
+ 
+ # Public dependency on some libraries required when using Mingw
+ if(WIN32 AND ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU|Clang")
+-- 
+2.20.1.windows.1
+


### PR DESCRIPTION
This pull request enables Fiber support by adding `TRACY_FIBERS=ON`. Upstream [notes](https://github.com/wolfpld/tracy/blob/16405715a6e4932c2b67548f433498f1bd93b619/NEWS#L514-L522) a potential performance impact, but it's expected to be minor. If concerns remain, we can consider introducing this as a new variant with a distinct build string

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
