### PR TITLE
Add tracy-capture and tracy-csvexport CLI outputs

### DIFF
--- a/recipe/build_tracy_capture.bat
+++ b/recipe/build_tracy_capture.bat
@@ -1,0 +1,15 @@
+cd capture
+
+rm -rf build
+mkdir build
+cd build
+
+cmake .. ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DNO_ISA_EXTENSIONS=ON ^
+    -GNinja ^
+    -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%"
+
+cmake --build . --parallel %CPU_COUNT%
+cmake --build . --target install

--- a/recipe/build_tracy_capture.sh
+++ b/recipe/build_tracy_capture.sh
@@ -11,7 +11,6 @@ fi
 
 cmake ${CMAKE_ARGS} .. \
     -DCMAKE_BUILD_TYPE=Release \
-    -DLEGACY=TRUE \
     -DNO_ISA_EXTENSIONS=ON \
     -DDOWNLOAD_CAPSTONE=FALSE \
     -GNinja

--- a/recipe/build_tracy_capture.sh
+++ b/recipe/build_tracy_capture.sh
@@ -10,7 +10,8 @@ if [[ "${target_platform}" == osx-* ]]; then
 
     # pugixml use CXX 20 module and need clang-scan-deps.
     # It's installed by the clang-tools package, but it doesn't have the right CMAKE_TOOLCHAIN_PREFIX.
-    CMAKE_CUSTOM_ARGS="-DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS="clang-scan-deps""
+    CLANG_SCAN_DEPS=$(which clang-scan-deps)
+    CMAKE_CUSTOM_ARGS="-DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS=${CLANG_SCAN_DEPS}"
 fi
 
 cmake ${CMAKE_ARGS} ${CMAKE_CUSTOM_ARGS} .. \

--- a/recipe/build_tracy_capture.sh
+++ b/recipe/build_tracy_capture.sh
@@ -7,9 +7,13 @@ mkdir build && cd build
 
 if [[ "${target_platform}" == osx-* ]]; then
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+
+    # pugixml use CXX 20 module and need clang-scan-deps.
+    # It's installed by the clang-tools package, but it doesn't have the right CMAKE_TOOLCHAIN_PREFIX.
+    CMAKE_CUSTOM_ARGS="-DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS="clang-scan-deps""
 fi
 
-cmake ${CMAKE_ARGS} .. \
+cmake ${CMAKE_ARGS} ${CMAKE_CUSTOM_ARGS} .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DNO_ISA_EXTENSIONS=ON \
     -DDOWNLOAD_CAPSTONE=FALSE \

--- a/recipe/build_tracy_capture.sh
+++ b/recipe/build_tracy_capture.sh
@@ -7,15 +7,11 @@ mkdir build && cd build
 
 if [[ "${target_platform}" == osx-* ]]; then
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
-
-    # pugixml use CXX 20 module and need clang-scan-deps.
-    # It's installed by the clang-tools package, but it doesn't have the right CMAKE_TOOLCHAIN_PREFIX.
-    CLANG_SCAN_DEPS=$(which clang-scan-deps)
-    CMAKE_CUSTOM_ARGS="-DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS=${CLANG_SCAN_DEPS}"
 fi
 
-cmake ${CMAKE_ARGS} ${CMAKE_CUSTOM_ARGS} .. \
+cmake ${CMAKE_ARGS} .. \
     -DCMAKE_BUILD_TYPE=Release \
+    -DLEGACY=TRUE \
     -DNO_ISA_EXTENSIONS=ON \
     -DDOWNLOAD_CAPSTONE=FALSE \
     -GNinja

--- a/recipe/build_tracy_capture.sh
+++ b/recipe/build_tracy_capture.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cd capture
+
+rm -rf build
+mkdir build && cd build
+
+if [[ "${target_platform}" == osx-* ]]; then
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+cmake ${CMAKE_ARGS} .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DNO_ISA_EXTENSIONS=ON \
+    -DDOWNLOAD_CAPSTONE=FALSE \
+    -GNinja
+
+cmake --build . --parallel ${CPU_COUNT}
+cmake --build . --target install

--- a/recipe/build_tracy_csvexport.bat
+++ b/recipe/build_tracy_csvexport.bat
@@ -1,0 +1,15 @@
+cd csvexport
+
+rm -rf build
+mkdir build
+cd build
+
+cmake .. ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DNO_ISA_EXTENSIONS=ON ^
+    -GNinja ^
+    -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%"
+
+cmake --build . --parallel %CPU_COUNT%
+cmake --build . --target install

--- a/recipe/build_tracy_csvexport.sh
+++ b/recipe/build_tracy_csvexport.sh
@@ -11,7 +11,6 @@ fi
 
 cmake ${CMAKE_ARGS} .. \
     -DCMAKE_BUILD_TYPE=Release \
-    -DLEGACY=TRUE \
     -DNO_ISA_EXTENSIONS=ON \
     -DDOWNLOAD_CAPSTONE=FALSE \
     -GNinja

--- a/recipe/build_tracy_csvexport.sh
+++ b/recipe/build_tracy_csvexport.sh
@@ -10,7 +10,8 @@ if [[ "${target_platform}" == osx-* ]]; then
 
     # pugixml use CXX 20 module and need clang-scan-deps.
     # It's installed by the clang-tools package, but it doesn't have the right CMAKE_TOOLCHAIN_PREFIX.
-    CMAKE_CUSTOM_ARGS="-DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS="clang-scan-deps""
+    CLANG_SCAN_DEPS=$(which clang-scan-deps)
+    CMAKE_CUSTOM_ARGS="-DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS=${CLANG_SCAN_DEPS}"
 fi
 
 cmake ${CMAKE_ARGS} ${CMAKE_CUSTOM_ARGS} .. \

--- a/recipe/build_tracy_csvexport.sh
+++ b/recipe/build_tracy_csvexport.sh
@@ -7,9 +7,13 @@ mkdir build && cd build
 
 if [[ "${target_platform}" == osx-* ]]; then
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+
+    # pugixml use CXX 20 module and need clang-scan-deps.
+    # It's installed by the clang-tools package, but it doesn't have the right CMAKE_TOOLCHAIN_PREFIX.
+    CMAKE_CUSTOM_ARGS="-DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS="clang-scan-deps""
 fi
 
-cmake ${CMAKE_ARGS} .. \
+cmake ${CMAKE_ARGS} ${CMAKE_CUSTOM_ARGS} .. \
     -DCMAKE_BUILD_TYPE=Release \
     -DNO_ISA_EXTENSIONS=ON \
     -DDOWNLOAD_CAPSTONE=FALSE \

--- a/recipe/build_tracy_csvexport.sh
+++ b/recipe/build_tracy_csvexport.sh
@@ -7,15 +7,11 @@ mkdir build && cd build
 
 if [[ "${target_platform}" == osx-* ]]; then
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
-
-    # pugixml use CXX 20 module and need clang-scan-deps.
-    # It's installed by the clang-tools package, but it doesn't have the right CMAKE_TOOLCHAIN_PREFIX.
-    CLANG_SCAN_DEPS=$(which clang-scan-deps)
-    CMAKE_CUSTOM_ARGS="-DCMAKE_CXX_COMPILER_CLANG_SCAN_DEPS=${CLANG_SCAN_DEPS}"
 fi
 
-cmake ${CMAKE_ARGS} ${CMAKE_CUSTOM_ARGS} .. \
+cmake ${CMAKE_ARGS} .. \
     -DCMAKE_BUILD_TYPE=Release \
+    -DLEGACY=TRUE \
     -DNO_ISA_EXTENSIONS=ON \
     -DDOWNLOAD_CAPSTONE=FALSE \
     -GNinja

--- a/recipe/build_tracy_csvexport.sh
+++ b/recipe/build_tracy_csvexport.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cd csvexport
+
+rm -rf build
+mkdir build && cd build
+
+if [[ "${target_platform}" == osx-* ]]; then
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+cmake ${CMAKE_ARGS} .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DNO_ISA_EXTENSIONS=ON \
+    -DDOWNLOAD_CAPSTONE=FALSE \
+    -GNinja
+
+cmake --build . --parallel ${CPU_COUNT}
+cmake --build . --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,48 @@ outputs:
       commands:
         - test -f $PREFIX/lib/libTracyClient${SHLIB_EXT}            # [not win]
         - if not exist %PREFIX%\Library\bin\TracyClient.dll exit 1  # [win]
+  - name: {{ pkg_name }}-capture
+    script: build_tracy_capture.sh  # [not win]
+    script: build_tracy_capture.bat  # [win]
+    build:
+      skip: true  # [ppc64le or aarch64]
+    requirements:
+      build:
+        - cmake
+        - ninja
+        - pkg-config
+        - {{ compiler('cxx') }}
+        - {{ stdlib("c") }}
+      host:
+        - libcapstone   # [linux or osx]
+        - tbb-devel
+      run:
+    test:
+      commands:
+        - test -f $PREFIX/bin/tracy-capture              # [not win]
+        - if not exist %PREFIX%\Library\bin\tracy-capture.exe exit 1  # [win]
+        - tracy-capture --help
+  - name: {{ pkg_name }}-csvexport
+    script: build_tracy_csvexport.sh  # [not win]
+    script: build_tracy_csvexport.bat  # [win]
+    build:
+      skip: true  # [ppc64le or aarch64]
+    requirements:
+      build:
+        - cmake
+        - ninja
+        - pkg-config
+        - {{ compiler('cxx') }}
+        - {{ stdlib("c") }}
+      host:
+        - libcapstone   # [linux or osx]
+        - tbb-devel
+      run:
+    test:
+      commands:
+        - test -f $PREFIX/bin/tracy-csvexport              # [not win]
+        - if not exist %PREFIX%\Library\bin\tracy-csvexport.exe exit 1  # [win]
+        - tracy-csvexport --help
   - name: {{ pkg_name }}-gui
     script: build_tracy_gui.sh  # [not win]
     script: build_tracy_gui.bat  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,6 @@ outputs:
         - pkg-config
         - {{ compiler('cxx') }}
         - {{ stdlib("c") }}
-        - clang-tools  # [osx]
       host:
         - freetype
         - libcurl
@@ -85,7 +84,6 @@ outputs:
         - pkg-config
         - {{ compiler('cxx') }}
         - {{ stdlib("c") }}
-        - clang-tools  # [osx]
       host:
         - freetype
         - libcurl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,6 +66,7 @@ outputs:
         - libcapstone   # [linux or osx]
         - xorg-libx11   # [linux]
         - tbb-devel
+        - pugixml
       run:
     test:
       commands:
@@ -94,6 +95,7 @@ outputs:
         - libcapstone   # [linux or osx]
         - xorg-libx11   # [linux]
         - tbb-devel
+        - pugixml
       run:
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,14 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ stdlib("c") }}
       host:
+        - freetype
+        - libcurl
+        - zlib
+        - glfw
+        - dbus          # [linux]
+        - libegl-devel  # [linux]
         - libcapstone   # [linux or osx]
+        - xorg-libx11   # [linux]
         - tbb-devel
       run:
     test:
@@ -78,7 +85,14 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ stdlib("c") }}
       host:
+        - freetype
+        - libcurl
+        - zlib
+        - glfw
+        - dbus          # [linux]
+        - libegl-devel  # [linux]
         - libcapstone   # [linux or osx]
+        - xorg-libx11   # [linux]
         - tbb-devel
       run:
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,7 @@ outputs:
       commands:
         - test -f $PREFIX/bin/tracy-capture              # [not win]
         - if not exist %PREFIX%\Library\bin\tracy-capture.exe exit 1  # [win]
-        - tracy-capture --help
+        - tracy-capture --help || true
   - name: {{ pkg_name }}-csvexport
     script: build_tracy_csvexport.sh  # [not win]
     script: build_tracy_csvexport.bat  # [win]
@@ -101,7 +101,7 @@ outputs:
       commands:
         - test -f $PREFIX/bin/tracy-csvexport              # [not win]
         - if not exist %PREFIX%\Library\bin\tracy-csvexport.exe exit 1  # [win]
-        - tracy-csvexport --help
+        - tracy-csvexport --help || true
   - name: {{ pkg_name }}-gui
     script: build_tracy_gui.sh  # [not win]
     script: build_tracy_gui.bat  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,7 @@ outputs:
         - pkg-config
         - {{ compiler('cxx') }}
         - {{ stdlib("c") }}
+        - clang-tools  # [osx]
       host:
         - freetype
         - libcurl
@@ -84,6 +85,7 @@ outputs:
         - pkg-config
         - {{ compiler('cxx') }}
         - {{ stdlib("c") }}
+        - clang-tools  # [osx]
       host:
         - freetype
         - libcurl


### PR DESCRIPTION
Adds two headless CLI tool outputs:

- **tracy-capture** — saves `.tracy` traces from a running app (no GUI needed)
- **tracy-csvexport** — exports `.tracy` zone data to CSV for programmatic analysis

Both only need TracyServer + TracyGetOpt (no GUI deps like GLFW/ImGui/freetype).